### PR TITLE
Add alt tag to pictures, remove data from gallery page

### DIFF
--- a/Jormungandr/templates/Jormungandr/gallery.html
+++ b/Jormungandr/templates/Jormungandr/gallery.html
@@ -27,7 +27,6 @@
                                     <h4 class="card-title">
                                         <a href="{% url 'gallery' album.pk %}">{{ album.name }}</a>
                                     </h4>
-                                    <p class="card-text">Gemaakt op {{ album.created_at|date:'d/m/Y' }}</p>
                                 </div>
                             </div>
                         </div>

--- a/Jormungandr/templates/Jormungandr/pictures.html
+++ b/Jormungandr/templates/Jormungandr/pictures.html
@@ -9,7 +9,7 @@
                 <ol>
                     <li><a href="{% url 'index' %}">Home</a></li>
                     <li><a href="{% url 'albums' %}">Foto's</a></li>
-                    <li>Album {{ album.name }}</li>
+                    <li>{{ album.name }}</li>
                 </ol>
             </div>
         </section>

--- a/Jormungandr/templates/Jormungandr/pictures.html
+++ b/Jormungandr/templates/Jormungandr/pictures.html
@@ -21,7 +21,7 @@
             <div class="section-title" data-aos="fade-in" data-aos-delay="100">
                 <h2>Foto's</h2>
                 <p>
-                    Gepost op {{ album.created_at|date:'d/m/Y' }}
+                    {{ album.created_at|date:'d M Y' }}
                 </p>
             </div>
             {% if album.picture_set.all %}
@@ -29,7 +29,7 @@
                     {% for picture in album.picture_set.all %}
                         <div class="col-lg-4 col-md-6 portfolio-item">
                             <div class="portfolio-wrap">
-                                <img src="{{ picture.link }}" class="img-fluid" alt="">
+                                <img src="{{ picture.link }}" class="img-fluid" alt="{{ picture.name }}">
                                 <div class="portfolio-links">
                                     <a href="{{ picture.link }}" data-gall="portfolioGallery"
                                        class="venobox"


### PR DESCRIPTION
Fills up the alt tag of the pictures with the mandatory name of the picture

Remove date from gallery page
Just show date on album
Remove mention of `album` on breadcrumb