### PR TITLE
Upgrade Django from 3.0.5 to 3.2.14

### DIFF
--- a/Jormungandr/context_processors.py
+++ b/Jormungandr/context_processors.py
@@ -24,6 +24,4 @@ def parameters(request):
 
 
 def footer_pages(request):
-    pages = FooterPage.objects.all()
-    print(pages)
     return {'footer_pages': FooterPage.objects.all()}

--- a/Jormungandr/settings/general.py
+++ b/Jormungandr/settings/general.py
@@ -116,3 +116,7 @@ MEDIA_URL = '/files/'
 # STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.staticfiles_storage'
 
 LOGIN_URL = '/intranet/login_user'
+
+# Change the default generated key from AutoField to BigAutoField
+# This will make migrating to Django 4 later easier as AutoField will be deprecated
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/Jormungandr/settings/general.py
+++ b/Jormungandr/settings/general.py
@@ -113,6 +113,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'files')
 MEDIA_URL = '/files/'
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.CachedStaticFilesStorage'
+# STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.staticfiles_storage'
 
 LOGIN_URL = '/intranet/login_user'

--- a/Jormungandr/views.py
+++ b/Jormungandr/views.py
@@ -17,7 +17,7 @@ def index(request):
     dt = make_aware(time)
 
     return render(request, 'Jormungandr/index.html', {"pictures": Picture.objects.filter(is_carousel_pic=True),
-                                                      'events': Event.objects.filter(start__gt=dt).order_by('start')})
+                                                      'events': Event.objects.filter(end__gt=dt).order_by('start')})
 
 
 def cms(request, page):
@@ -50,7 +50,7 @@ def praesidia(request):
 def events(request):
     time = datetime.now()
     dt = make_aware(time)
-    _events = Event.objects.filter(start__gt=dt).order_by('start')
+    _events = Event.objects.filter(end__gt=dt).order_by('start')
     return render(request, 'Jormungandr/events.html', {'events': _events})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.0.5
+Django==3.1.14
 django-markdownx
 django-multiselectfield
 psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.14
+Django==3.2.14
 django-markdownx
 django-multiselectfield
 psycopg2


### PR DESCRIPTION
Upgrade Django from version 3.0.5 to 3.2.14

All functions of the website have been tested.
Remove print statement in footer pages

> Extra: Changed filtering of events, so that an event only disappears from the site if the end date has been reached